### PR TITLE
Contacts: Ignore device null account.

### DIFF
--- a/src/com/android/contacts/model/DeviceLocalAccountLocator.java
+++ b/src/com/android/contacts/model/DeviceLocalAccountLocator.java
@@ -21,7 +21,6 @@ import android.content.Context;
 
 import com.android.contacts.Experiments;
 import com.android.contacts.model.account.AccountWithDataSet;
-import com.android.contacts.model.account.GoogleAccountType;
 import com.android.contactsbind.ObjectFactory;
 import com.android.contactsbind.experiments.Flags;
 
@@ -69,7 +68,7 @@ public abstract class DeviceLocalAccountLocator {
             return new Cp2DeviceLocalAccountLocator(context.getContentResolver(),
                     ObjectFactory.getDeviceLocalAccountTypeFactory(context), knownTypes);
         } else {
-            return new NexusDeviceAccountLocator(accountManager);
+            return new NexusDeviceAccountLocator();
         }
     }
 
@@ -82,24 +81,9 @@ public abstract class DeviceLocalAccountLocator {
      * </p>
      */
     public static class NexusDeviceAccountLocator extends DeviceLocalAccountLocator {
-
-        private final AccountManager mAccountManager;
-
-        public NexusDeviceAccountLocator(AccountManager accountManager) {
-            mAccountManager = accountManager;
-        }
-
         @Override
         public List<AccountWithDataSet> getDeviceLocalAccounts() {
-            @SuppressWarnings("MissingPermission")
-            final Account[] accounts = mAccountManager
-                    .getAccountsByType(GoogleAccountType.ACCOUNT_TYPE);
-
-            if (accounts.length > 0) {
-                return Collections.emptyList();
-            } else {
-                return Collections.singletonList(AccountWithDataSet.getNullAccount());
-            }
+            return Collections.emptyList();
         }
     }
 }


### PR DESCRIPTION
As of commit 2cb5e0752a8def94c386a02213c54bb1be4b6344 which adds device contact,
the behavior is correct if there is a google account already setup, otherwise
there are two device contacts shown. So, always ignore null account.

Change-Id: I9f18a45efcaa93b8583013beb5995bf85ae58dcd
Signed-off-by: Toha <tohenk@yahoo.com>