### PR TITLE
Contacts: Remove unused boolean resource

### DIFF
--- a/res/values-ja/donottranslate_config.xml
+++ b/res/values-ja/donottranslate_config.xml
@@ -32,7 +32,4 @@
 
     <!-- If true, the order of name fields in the editor is primary (i.e. given name first) -->
     <bool name="config_editor_field_order_primary">false</bool>
-
-    <!-- If true, phonetic name is included in the contact editor by default -->
-    <bool name="config_editor_include_phonetic_name">true</bool>
 </resources>


### PR DESCRIPTION
Fixes:
warn: removing resource com.android.contacts:bool/config_editor_include_phonetic_name
without required default value.

Change-Id: I924a4815d07854ad5ae04ca7ddf87f738a4bd277